### PR TITLE
Fix CODEOWNERS team reference

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-# * @hashicorp/tf-core-cloud
+* @hashicorp-forge/team-tf-core-cloud


### PR DESCRIPTION
Updating this to match the team name as it exists in this GH org ([hashicorp/team-tf-core-cloud](https://github.com/orgs/hashicorp-forge/teams/team-tf-core-cloud)).